### PR TITLE
.DS_Store の無視

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # VScode
 .vscode/
+
+# Mac OS
+.DS_Store


### PR DESCRIPTION
- Mac OS上で生成される`.DS_Store`ファイルを非追跡にする